### PR TITLE
Normalize result surfaced to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,15 @@ var wrapDelete = function (script) {
 
 module.exports = function (params) {
 
+  function normalize(cb) { 
+    return function (error, result, out, stats) { 
+      cb(error, result && result.user, out, stats); 
+    }
+  }
+  
   var execute = function (script, configuration, user, callback) {
     configuration = configuration || {};
-    var args = [user, {}, callback];
+    var args = [user, {}, normalize(callback)];
     runInSandbox(script, args, configuration, params);
   };
 


### PR DESCRIPTION
The latest version of `auth0-rules-testharness` returns a result object of the form `{ user: {}, context: {} }`, but for this test harness I believe only the value contained within `result.user` is relevant.